### PR TITLE
Remove invalid `break` syntax

### DIFF
--- a/scripts/__SnitchExceptionHandler/__SnitchExceptionHandler.gml
+++ b/scripts/__SnitchExceptionHandler/__SnitchExceptionHandler.gml
@@ -64,7 +64,7 @@ function __SnitchExceptionHandler(_struct)
                     case 3: _text = _event.__GetCompressedExceptionString(); break;
                 }
                 
-                clipboard_set_text("#####" + _text + "#####"); break;
+                clipboard_set_text("#####" + _text + "#####");
                 show_message(SNITCH_CRASH_CLIPBOARD_ACCEPT_MESSAGE);
             }
         }


### PR DESCRIPTION
`break` is used here without an enclosing switch or loop statement. It should be removed to avoid misbehaviour between platforms.