### PR TITLE
Fix crash in example/demo: No-longer-existing async HTTP functions in oTest that are handled by __SnitchController nowadays

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <h1 align="center">Snitch 4.1.0</h1>
 
-<p align="center">Logging and crash handling system for GameMaker Studio 2022 LTS by <a href="https://www.jujuadams.com/" target="_blank">Juju Adams</a></p>
+<p align="center">Logging and crash handling system for GameMaker 2022 LTS by <a href="https://www.jujuadams.com/" target="_blank">Juju Adams</a></p>
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@
 - ### [Download the .yymps](https://github.com/JujuAdams/Snitch/releases/)
 - ### Read the [documentation](http://jujuadams.github.io/Snitch)
 - ### Talk about Snitch on the [Discord server](https://discord.gg/8krYCqr)
+- ### You may also like [GMSentry](https://marketplace.yoyogames.com/assets/7917/gmsentry), [gmlogging-suite](https://github.com/meseta/gmlogging-suite), and [YoYoGames' Firebase Crashlytics Extension](https://marketplace.yoyogames.com/assets/10448/firebase-crashlytics-ext)

--- a/objects/oTest/Other_62.gml
+++ b/objects/oTest/Other_62.gml
@@ -1,2 +1,0 @@
-//Make sure we're properly handling HTTP events that Snitch fires off
-SnitchHTTPAsyncEvent();

--- a/objects/oTest/Other_68.gml
+++ b/objects/oTest/Other_68.gml
@@ -1,2 +1,0 @@
-//Make sure we're properly handling Networking events that Snitch fires off
-SnitchNetworkingAsyncEvent();

--- a/objects/oTest/oTest.yy
+++ b/objects/oTest/oTest.yy
@@ -26,8 +26,6 @@
     {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","isDnD":false,"eventNum":0,"eventType":0,"collisionObjectId":null,},
     {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","isDnD":false,"eventNum":0,"eventType":8,"collisionObjectId":null,},
     {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","isDnD":false,"eventNum":3,"eventType":7,"collisionObjectId":null,},
-    {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","isDnD":false,"eventNum":62,"eventType":7,"collisionObjectId":null,},
-    {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","isDnD":false,"eventNum":68,"eventType":7,"collisionObjectId":null,},
   ],
   "properties": [],
   "overriddenProperties": [],

--- a/scripts/__SnitchClassRequest/__SnitchClassRequest.gml
+++ b/scripts/__SnitchClassRequest/__SnitchClassRequest.gml
@@ -173,7 +173,7 @@ function __SnitchGameAnalyticsHTTPRequest(_request)
 {
 	static __snitchState = __SnitchState();
 	
-    // "The authentication value is a HMAC SHA-256 digest of the raw body content from the request using the secret key (private key) as the hashing key and then encoding it using base64."
+    //"The authentication value is a HMAC SHA-256 digest of the raw body content from the request using the secret key (private key) as the hashing key and then encoding it using base64."
     var _hashArray = __SnitchHMACSHA256(SNITCH_GAMEANALYTICS_SECRET_KEY, _request.content, false);
     
     //Get the base64 encoded version of the digest, whilst also handling endianness conversion

--- a/scripts/__SnitchConfigServiceKeys/__SnitchConfigServiceKeys.gml
+++ b/scripts/__SnitchConfigServiceKeys/__SnitchConfigServiceKeys.gml
@@ -2,11 +2,11 @@
 //This can be found via Settings -> Client Keys (under the SDK SETUP header on the left-hand side)
 #macro SNITCH_SENTRY_DSN_URL  ""
 
-// GameAnalytics keys
-// Found via Settings -> Game Keys for your game
+//GameAnalytics keys
+//Found via Settings -> Game Keys for your game
 #macro SNITCH_GAMEANALYTICS_GAME_KEY    ""
 #macro SNITCH_GAMEANALYTICS_SECRET_KEY  ""
 
-// Bugsnag key
-// Found via Settings (top-right on the project page) -> Project Settings - Notifier API key
+//Bugsnag key
+//Found via Settings (top-right on the project page) -> Project Settings - Notifier API key
 #macro SNITCH_BUGSNAG_NOTIFIER_API_KEY  ""

--- a/scripts/__SnitchConfigServices/__SnitchConfigServices.gml
+++ b/scripts/__SnitchConfigServices/__SnitchConfigServices.gml
@@ -4,7 +4,7 @@
 //  3. Do your absolute best to protect the privacy of your players
 //
 //Set this macro to <true> to acknowledge this warning
-#macro SNITCH_SERVICE_WARNING_READ  true
+#macro SNITCH_SERVICE_WARNING_READ  false
 
 //Which service to use
 //There are 4 modes:

--- a/scripts/__SnitchExceptionHandler/__SnitchExceptionHandler.gml
+++ b/scripts/__SnitchExceptionHandler/__SnitchExceptionHandler.gml
@@ -64,7 +64,7 @@ function __SnitchExceptionHandler(_struct)
                     case 3: _text = _event.__GetCompressedExceptionString(); break;
                 }
                 
-                clipboard_set_text("#####" + _text + "#####"); break;
+                clipboard_set_text("#####" + _text + "#####");
                 show_message(SNITCH_CRASH_CLIPBOARD_ACCEPT_MESSAGE);
             }
         }


### PR DESCRIPTION
plus a small comment stylization fix in two places